### PR TITLE
Add Local Disk Check and Temporary Snapshot Copy for pg_restore

### DIFF
--- a/src/PostgresSnapshot.php
+++ b/src/PostgresSnapshot.php
@@ -6,7 +6,6 @@ use Spatie\DbSnapshots\Events\LoadedSnapshot;
 use Spatie\DbSnapshots\Events\LoadingSnapshot;
 use Spatie\DbSnapshots\Snapshot;
 use Weslinkde\PostgresTools\Support\PostgresHelper;
-use Illuminate\Support\Facades\Storage;
 
 use function Laravel\Prompts\spin;
 
@@ -16,7 +15,7 @@ class PostgresSnapshot extends Snapshot
     public function streamToLocalFile($sourceDisk, $sourcePath, $localFilePath)
     {
         // Open a read stream from the source disk
-        $readStream = Storage::disk($sourceDisk)->readStream($sourcePath);
+        $readStream = $sourceDisk->readStream($sourcePath);
 
         if ($readStream === false) {
             throw new \Exception("Failed to open stream for {$sourcePath} on {$sourceDisk} disk.");
@@ -60,7 +59,7 @@ class PostgresSnapshot extends Snapshot
             $dbDumpFilePath = $this->disk->path($this->fileName);
         } else {
             $dbDumpFilePath = rtrim(config('db-snapshots.temporary_directory_path'), '/') . '/' . $this->fileName;
-            $this->streamToLocalFile(config('postgres-tools.disk'), $this->fileName, $dbDumpFilePath);
+            $this->streamToLocalFile($this->disk, $this->fileName, $dbDumpFilePath);
         }
 
         spin(

--- a/src/PostgresSnapshot.php
+++ b/src/PostgresSnapshot.php
@@ -6,11 +6,41 @@ use Spatie\DbSnapshots\Events\LoadedSnapshot;
 use Spatie\DbSnapshots\Events\LoadingSnapshot;
 use Spatie\DbSnapshots\Snapshot;
 use Weslinkde\PostgresTools\Support\PostgresHelper;
+use Illuminate\Support\Facades\Storage;
 
 use function Laravel\Prompts\spin;
 
 class PostgresSnapshot extends Snapshot
 {
+
+    public function streamToLocalFile($sourceDisk, $sourcePath, $localFilePath)
+    {
+        // Open a read stream from the source disk
+        $readStream = Storage::disk($sourceDisk)->readStream($sourcePath);
+
+        if ($readStream === false) {
+            throw new \Exception("Failed to open stream for {$sourcePath} on {$sourceDisk} disk.");
+        }
+
+        // Open a file handle for writing locally
+        $localFile = fopen($localFilePath, 'w');
+
+        if ($localFile === false) {
+            fclose($readStream); // Close the read stream if local file open fails
+            throw new \Exception("Failed to open local file {$localFilePath} for writing.");
+        }
+
+        // Write the contents from the read stream to the local file in chunks
+        while (!feof($readStream)) {
+            // Read a chunk of data and write it to the local file
+            fwrite($localFile, fread($readStream, 8192));
+        }
+
+        // Close both file handles
+        fclose($readStream);
+        fclose($localFile);
+    }
+
     public function load(?string $connectionName = null, bool $dropTables = true): void
     {
         event(new LoadingSnapshot($this));
@@ -24,12 +54,23 @@ class PostgresSnapshot extends Snapshot
         }
 
         $postgresHelper = PostgresHelper::createForConnection($connectionName);
-        $dbDumpFilePath = $this->disk->path($this->fileName);
+        $isDiskLocal = $this->disk->getConfig()['driver'] === 'local';
+
+        if ($isDiskLocal) {
+            $dbDumpFilePath = $this->disk->path($this->fileName);
+        } else {
+            $dbDumpFilePath = rtrim(config('db-snapshots.temporary_directory_path'), '/') . '/' . $this->fileName;
+            $this->streamToLocalFile(config('postgres-tools.disk'), $this->fileName, $dbDumpFilePath);
+        }
 
         spin(
             fn () => $postgresHelper->restoreSnapshot($dbDumpFilePath),
             'Importing snapshot '.$this->name.'...'
         );
+
+        if (! $isDiskLocal && file_exists($dbDumpFilePath)) {
+            unlink($dbDumpFilePath);
+        }
 
         event(new LoadedSnapshot($this));
     }

--- a/src/PostgresSnapshot.php
+++ b/src/PostgresSnapshot.php
@@ -1,24 +1,25 @@
 <?php
 
-namespace Weslinkde\PostgresTools;
+namespace App\Aliases\weslinkde\LaravelPostgresTools\src;
 
+use Exception;
+use Spatie\DbSnapshots\Snapshot;
 use Spatie\DbSnapshots\Events\LoadedSnapshot;
 use Spatie\DbSnapshots\Events\LoadingSnapshot;
-use Spatie\DbSnapshots\Snapshot;
+use Weslinkde\PostgresTools\Exceptions\CannotCreateConnection;
 use Weslinkde\PostgresTools\Support\PostgresHelper;
 
 use function Laravel\Prompts\spin;
 
 class PostgresSnapshot extends Snapshot
 {
-
     public function streamToLocalFile($sourceDisk, $sourcePath, $localFilePath)
     {
         // Open a read stream from the source disk
         $readStream = $sourceDisk->readStream($sourcePath);
 
         if ($readStream === false) {
-            throw new \Exception("Failed to open stream for {$sourcePath} on {$sourceDisk} disk.");
+            throw new Exception("Failed to open stream for {$sourcePath} on {$sourceDisk} disk.");
         }
 
         // Open a file handle for writing locally
@@ -26,11 +27,11 @@ class PostgresSnapshot extends Snapshot
 
         if ($localFile === false) {
             fclose($readStream); // Close the read stream if local file open fails
-            throw new \Exception("Failed to open local file {$localFilePath} for writing.");
+            throw new Exception("Failed to open local file {$localFilePath} for writing.");
         }
 
         // Write the contents from the read stream to the local file in chunks
-        while (!feof($readStream)) {
+        while (! feof($readStream)) {
             // Read a chunk of data and write it to the local file
             fwrite($localFile, fread($readStream, 8192));
         }
@@ -40,6 +41,10 @@ class PostgresSnapshot extends Snapshot
         fclose($localFile);
     }
 
+    /**
+     * @throws CannotCreateConnection
+     * @throws Exception
+     */
     public function load(?string $connectionName = null, bool $dropTables = true): void
     {
         event(new LoadingSnapshot($this));
@@ -58,13 +63,17 @@ class PostgresSnapshot extends Snapshot
         if ($isDiskLocal) {
             $dbDumpFilePath = $this->disk->path($this->fileName);
         } else {
-            $dbDumpFilePath = rtrim(config('db-snapshots.temporary_directory_path'), '/') . '/' . $this->fileName;
+            $dbDumpDirectory = rtrim(config('db-snapshots.temporary_directory_path'), '/') . '/';
+            $dbDumpFilePath = $dbDumpDirectory . $this->fileName;
+            if (! file_exists($dbDumpDirectory)) {
+                mkdir($dbDumpDirectory, 0777, true);
+            }
             $this->streamToLocalFile($this->disk, $this->fileName, $dbDumpFilePath);
         }
 
         spin(
             fn () => $postgresHelper->restoreSnapshot($dbDumpFilePath),
-            'Importing snapshot '.$this->name.'...'
+            'Importing snapshot ' . $this->name . '...'
         );
 
         if (! $isDiskLocal && file_exists($dbDumpFilePath)) {

--- a/src/Support/PostgresHelper.php
+++ b/src/Support/PostgresHelper.php
@@ -117,7 +117,7 @@ class PostgresHelper
         $jobs = config('postgres-tools.jobs', 1);
 
         $process = new Process(
-            command: ['pg_restore', '--jobs', $jobs ,'--host', $this->host, '--port', $this->port, '--username', $this->userName, '--no-owner', '--clean', '--role', $this->userName, '--dbname', $this->name, $filePath],
+            command: ['pg_restore', '--jobs', $jobs ,'--host', $this->host, '--port', $this->port, '--username', $this->userName, '--no-owner', '--clean', '--if-exists', '--role', $this->userName, '--dbname', $this->name, $filePath],
             env: ['PGPASSWORD' => $this->password]
         );
 


### PR DESCRIPTION
This PR enhances the snapshot loading process by verifying if the disk from which the snapshot will be loaded is "local." If the disk is not local, the snapshot is first copied to a predefined temporary directory to enable access. The snapshot is then loaded using pg_restore, and the local copy is deleted after the process completes.

Additionally, the `--if-exists` flag is added to the pg_restore command to prevent errors in cases where certain database objects already exist, improving robustness and ensuring smoother restore operations.